### PR TITLE
Add Logic for Private Wikis with Upgrade and Downgrades

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   include Pundit
   include ApplicationHelper
 
-  #before_action :configure_permitted_parameters, if: :devise_controller?
+  # before_action :configure_permitted_parameters, if: :devise_controller?
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   # Prevent CSRF attacks by raising an exception.
@@ -22,6 +22,6 @@ class ApplicationController < ActionController::Base
     # Sanitizer for Devise Account Signup
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     # Sanitizer for Devise Account Edit
-    devise_parameter_sanitizer.permit(:account_update, keys:[:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 end

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -4,20 +4,17 @@ class ChargesController < ApplicationController
   CHARGES_COST = 1_500
 
   def new
-
     @stripe_btn_data = {
-     key: "#{ Rails.configuration.stripe[:publishable_key] }",
-     description: "Blocipedia Premium Upgrade",
-     amount: upgrade_cost
-   }
-
+      key: Rails.configuration.stripe[:publishable_key].to_s,
+      description: 'Blocipedia Premium Upgrade',
+      amount: upgrade_cost
+    }
   end
 
   def create
-
     @user = current_user
     # Create a stripe customer for our charge
-    customer = Stripe::Customer.create(
+    customer = Stripe::Customer::create(
       email: @user.email,
       card: params[:stripeToken]
     )
@@ -29,14 +26,13 @@ class ChargesController < ApplicationController
       currency: 'usd'
     )
 
-    flash[:notice] = "Success - Thank You for Upgrading!"
+    flash[:notice] = 'Success - Thank You for Upgrading!'
     perform_upgrade
     redirect_to_default
 
-    rescue Stripe::CardError => e
+  rescue Stripe::CardError => e
     flash[:alert] = e.message
     redirect_to new_charge_path
-
   end
 
   private
@@ -52,5 +48,4 @@ class ChargesController < ApplicationController
   def redirect_to_default
     redirect_to wikis_path
   end
-
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,16 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   def downgrade
+    downgrade_posts
     current_user.downgrade_user
-    flash[:notice] = "Downgrade Complete"
+    flash[:notice] = 'Downgrade Complete'
     redirect_to(:back)
+  end
+
+  private
+
+  def downgrade_posts
+    current_user.wikis.all.each do |wiki|
+      wiki.update(private: false)
+    end
   end
 end

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -4,6 +4,8 @@ class WikisController < ApplicationController
 
   def index
     @wikis = Wiki.all
+    @my_public_wikis = current_user.wikis.where(private: false)
+    @my_premium_wikis = current_user.wikis.where(private: true)
   end
 
   def show
@@ -19,7 +21,7 @@ class WikisController < ApplicationController
     @user = current_user
     @wiki = @user.wikis.new(wiki_parameters)
     authorize @wiki
-  
+
     if @wiki.save
       flash[:notice] = wiki_instantiate_confirmed
       redirect_to @wiki

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,11 @@
 module ApplicationHelper
-
   def user_gem_display
-    if current_user.role == "admin"
-      image_tag("red-diamond.png", :size => "24x20")
-    elsif current_user.role == "premium"
-      image_tag("blue-diamond.png", :size => "24x20")
+    if current_user.role == 'admin'
+      image_tag('red-diamond.png', size: '24x20')
+    elsif current_user.role == 'premium'
+      image_tag('blue-diamond.png', size: '24x20')
     else
-      image_tag("black-diamond.png", :size => "24x20")
+      image_tag('black-diamond.png', size: '24x20')
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,4 +31,7 @@ class User < ActiveRecord::Base
   def set_role_to_standard
     update(role: 0)
   end
+
+  # This will downgrade posts
+  def downgrade_posts; end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,6 +1,5 @@
 # This is the ApplicationPolicy for the Pundit Authorization Gem
 class ApplicationPolicy < Struct.new(:user, :record)
-
   def initialize(user, record)
     @user = user
     @record = record

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -25,20 +25,20 @@ class WikiPolicy < ApplicationPolicy
   # Currently standard, premium, and admin roles have create permission
   def create_eligable_roles
     @user.premium? ||
-    @user.admin? ||
-    @user.standard?
+      @user.admin? ||
+      @user.standard?
   end
 
   # Currently standard, premium, and admin roles have update permission
   def update_eligable_roles
     @user.premium? ||
-    @user.admin? ||
-    @user.standard?
+      @user.admin? ||
+      @user.standard?
   end
 
   # Currently admin roles and wiki owner have delete permission
   def destroy_eligable_roles
     @user.admin? ||
-    @wiki.user_id == @user.id
+      @wiki.user_id == @user.id
   end
 end

--- a/app/views/users/registrations/_premium.html.erb
+++ b/app/views/users/registrations/_premium.html.erb
@@ -1,12 +1,15 @@
 <% if user.role == "admin" %>
   <h3>Board Administrator</h3>
+
   <p>Admin Dashboard Link (to be implimented)</p>
 <% elsif user.role == "premium" %>
   <h3>Premium Account Holder</h3>
+
   <p>
     Can't Handle the Pressure - Downgrade to Standard <br>
     Please note that any of your private wikis not deleted *WILL* be set to public!
   </p>
+
   <%= button_to "Downgrade", users_downgrade_path,
     :class => "downgrade-button",
     method: :post, data: {:confirm => "Please confirm downgrade! This cannot be reversed"} %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -51,4 +51,4 @@
 <h3>Cancel my Account</h3>
 <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
-<%= link_to "Back", :back %>
+<%= link_to("Back to Index", wikis_path) %>

--- a/app/views/wikis/_form.html.erb
+++ b/app/views/wikis/_form.html.erb
@@ -13,11 +13,11 @@
       </div>
 
       <div>
-        <%if ( (type == "new") && (current_user.premium? || current_user.admin? ) ) ||
-             ( (type == "edit") && (current_user.premium? && 'wiki.user_id' == current_user.id) ) ||
+        <%if ( (type == "new") && ( current_user.premium? || current_user.admin? ) ) ||
+             ( (type == "edit") && ( current_user.premium? ) && (wiki.user_id == current_user.id) ) ||
              ( (type == "edit") && current_user.admin?) %>
           <%= w.label :private do %>
-          <%= w.check_box :private %> Private Wiki?
+            <%= w.check_box :private %> Private Wiki?
           <% end %>
         <% end %>
       </div>

--- a/app/views/wikis/_personal_wikis.html.erb
+++ b/app/views/wikis/_personal_wikis.html.erb
@@ -1,0 +1,5 @@
+<% @my_public_wikis.each do |wiki| %>
+    <h5 class="media-heading">
+      <%= link_to wiki.title, wiki %>
+    </h5>
+<% end %>

--- a/app/views/wikis/_premium_wikis.html.erb
+++ b/app/views/wikis/_premium_wikis.html.erb
@@ -1,0 +1,5 @@
+<% @my_premium_wikis.each do |wiki| %>
+  <h5 class="media-heading">
+    <%= link_to wiki.title, wiki %>
+  </h5>
+<% end %>

--- a/app/views/wikis/_public_wikis.html.erb
+++ b/app/views/wikis/_public_wikis.html.erb
@@ -1,0 +1,7 @@
+<% @wikis.each do |wiki| %>
+  <% if ( wiki.user_id != current_user.id ) %>
+    <h5 class="media-heading">
+      <%= link_to wiki.title, wiki %>
+    </h5>
+  <% end %>
+<% end %>

--- a/app/views/wikis/index.html.erb
+++ b/app/views/wikis/index.html.erb
@@ -1,13 +1,23 @@
 <h1>Wiki Index</h1>
 <div class="row media">
   <div class="col-md-11 media-body">
-    <% @wikis.each do |wiki| %>
-      <h5 class="media-heading">
-        <%= link_to wiki.title, wiki %>
-      </h5>
+    <% unless @my_premium_wikis.empty? %>
+      <h4 class="premium-wikis-title"> Your Premium Wikis </h4>
+      <%= render partial: 'premium_wikis' %>
+    <% end %>
+
+    <% unless @my_public_wikis.empty? %>
+      <h4 class="personal-wikis-title"> Your Public Wikis </h4>
+      <%= render partial: 'personal_wikis'%>
+    <% end %>
+
+    <% unless @wikis.empty? %>
+      <h4 class="public-wikis-title"> Public Wikis </h4>
+      <%= render partial: 'public_wikis' %>
     <% end %>
   </div>
+
   <div class="col-md-1">
-    <%= render partial: 'new_button', locals: { wiki: @wiki } %>
+    <%= render partial: 'new_button' %>
   </div>
 </div>


### PR DESCRIPTION
Take a look. 

Most of this user story had been done with what I wrote previous.

I added a few more instance variables in the wiki index controllers to query the database directly to subsequently reduce conditional use in the views (for example, setting an instance variable containing all the users current private posts, and looping through those, VS using each loops to cycle through all wikis and filtering for posts that were assigned to the current user AND set to private). 

I definitely think that would be more scalable, although I am sure there are more efficiencies to be found. I am curious if this is the technique you would use or if there is something I should be doing elsewhere?

A lot of the groundwork for this was done in the previous user story, so really this checkpoint became all about view modification, where I would handle the logic, and finally adding the one additional function to set user wikis to public after downgrade.

This had definitely been a learning experience, as I keep modifying things to make the code all flow smoother. Still not professional level I think, but I feel confident that I am improving, especially in my thought processes behind doing things.